### PR TITLE
Proper names for providers

### DIFF
--- a/src/Kdyby/Clock/DI/ClockExtension.php
+++ b/src/Kdyby/Clock/DI/ClockExtension.php
@@ -40,8 +40,8 @@ class ClockExtension extends Nette\DI\CompilerExtension
 	);
 
 	public static $providers = array(
-		'standard' => 'Kdyby\Clock\Providers\StandardProvider',
-		'request' => 'Kdyby\Clock\Providers\RequestTimeProvider',
+		'standard' => 'Kdyby\Clock\Providers\CurrentProvider',
+		'request' => 'Kdyby\Clock\Providers\ConstantProvider',
 	);
 
 

--- a/src/Kdyby/Clock/Providers/ConstantProvider.php
+++ b/src/Kdyby/Clock/Providers/ConstantProvider.php
@@ -18,19 +18,19 @@ use Nette;
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */
-class RequestTimeProvider extends AbstractProvider
+class ConstantProvider extends AbstractProvider
 {
 
 	/**
-	 * @param string|int|\DateTime $httpRequestTime
+	 * @param string|int|\DateTime $time
 	 */
-	public function __construct($httpRequestTime)
+	public function __construct($time)
 	{
-		if ($httpRequestTime instanceof \DateTime) {
-			parent::__construct($httpRequestTime);
+		if ($time instanceof \DateTime) {
+			parent::__construct($time);
 
 		} else {
-			parent::__construct(new \DateTime(date('Y-m-d H:i:s', $httpRequestTime), new \DateTimeZone(date_default_timezone_get())));
+			parent::__construct(new \DateTime(date('Y-m-d H:i:s', $time), new \DateTimeZone(date_default_timezone_get())));
 		}
 	}
 

--- a/src/Kdyby/Clock/Providers/CurrentProvider.php
+++ b/src/Kdyby/Clock/Providers/CurrentProvider.php
@@ -15,7 +15,7 @@ namespace Kdyby\Clock\Providers;
 /**
  * @author Michael Moravec
  */
-class StandardProvider extends AbstractProvider
+class CurrentProvider extends AbstractProvider
 {
 
 	public function __construct()

--- a/tests/KdybyTests/Clock/ConstantProvider.phpt
+++ b/tests/KdybyTests/Clock/ConstantProvider.phpt
@@ -11,7 +11,7 @@
 namespace KdybyTests\Clock;
 
 use Kdyby;
-use Kdyby\Clock\Providers\RequestTimeProvider;
+use Kdyby\Clock\Providers\ConstantProvider;
 use Nette;
 use Tester;
 use Tester\Assert;
@@ -23,24 +23,24 @@ require_once __DIR__ . '/../bootstrap.php';
 /**
  * @author Filip Procházka <filip@prochazka.su>
  */
-class RequestTimeProviderTest extends Tester\TestCase
+class ConstantProviderTest extends Tester\TestCase
 {
 
 	public function testTimezones()
 	{
 		date_default_timezone_set('Europe/Prague');
 
-		$rtp = new RequestTimeProvider(1379123601);
+		$rtp = new ConstantProvider(1379123601);
 		Assert::same('Europe/Prague', $rtp->getTimezone()->getName());
 		Assert::same('2013-09-14 03:53:21 +02:00', $rtp->getDateTime()->format('Y-m-d H:i:s P'));
 
 		date_default_timezone_set('Europe/London');
 
-		$rtp = new RequestTimeProvider(1379123601);
+		$rtp = new ConstantProvider(1379123601);
 		Assert::same('Europe/London', $rtp->getTimezone()->getName());
 		Assert::same('2013-09-14 02:53:21 +01:00', $rtp->getDateTime()->format('Y-m-d H:i:s P'));
 	}
 
 }
 
-\run(new RequestTimeProviderTest());
+\run(new ConstantProviderTest());

--- a/tests/KdybyTests/Clock/Extension.phpt
+++ b/tests/KdybyTests/Clock/Extension.phpt
@@ -49,7 +49,7 @@ class ExtensionTest extends Tester\TestCase
 		$provider = $container->getByType('Kdyby\Clock\IDateTimeProvider');
 		/** @var \Kdyby\Clock\IDateTimeProvider $provider */
 
-		Assert::true($provider instanceof Kdyby\Clock\Providers\StandardProvider);
+		Assert::true($provider instanceof Kdyby\Clock\Providers\CurrentProvider);
 	}
 
 
@@ -60,7 +60,7 @@ class ExtensionTest extends Tester\TestCase
 		$provider = $container->getByType('Kdyby\Clock\IDateTimeProvider');
 		/** @var \Kdyby\Clock\IDateTimeProvider $provider */
 
-		Assert::true($provider instanceof Kdyby\Clock\Providers\RequestTimeProvider);
+		Assert::true($provider instanceof Kdyby\Clock\Providers\ConstantProvider);
 		Assert::same((string) $_SERVER['REQUEST_TIME'], $provider->getDateTime()->format('U'));
 
 		$_SERVER['REQUEST_TIME'] = 987654321;


### PR DESCRIPTION
RequestTimeProvider has nothing to do with RequestTime. It just stores argument with some light parsing (which is bit magic but out of scope of this pull), therefore renamed to ConstantProvider.
StandardProvider name references to undefined standard. I suggest renaming it to Current(Time)Provider or NowProvider (so it reads Kdyby **Clock** Providers **Now** Provider).

I can squash it if you don't use [github](https://github.com/github/hub) [cli](https://github.com/schacon/git-pulls) tools already.
